### PR TITLE
When re-submitting after failure, set error to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,10 @@ function Submission (data) {
 
 Submission.submit = function submit (state, fn) {
   if (state.pending()) return
+
+  state.error.set(null)
   state.pending.set(true)
+
   fn(createHandler(state))
 }
 

--- a/test.js
+++ b/test.js
@@ -44,3 +44,34 @@ test('error', function (t) {
 
   Submission.onData(submission, t.fail)
 })
+
+test('error then success', function (t) {
+  var submission = Submission()
+
+  submit(new Error('oh noes'))
+
+  Submission.onError(submission, function onError (err) {
+    t.equal(err.constructor, Error)
+    t.equal(err.message, 'oh noes')
+    t.deepEqual(submission.error(), {
+      message: 'oh noes'
+    })
+
+    submit(null, 'winning')
+    t.equal(submission.error(), null)
+
+    Submission.onData(submission, function (data) {
+      t.equal(data, 'winning')
+      t.equal(submission.error(), null)
+      t.end()
+    })
+  })
+
+  function submit (error, data) {
+    Submission.submit(submission, function (callback) {
+      nextTick(function () {
+        callback(error, data)
+      })
+    })
+  }
+})


### PR DESCRIPTION
This is a breaking change, but it fits how I expected the library to behave in the first place. Basically, each new submit makes the state pristine again.

This solves the following case:

1) User presses submit
- submission.pending is true, spinner is rendered

2) An error comes back
- submission.error is true, error is rendered

3) User fixes error and presses submit again
- submission.error is now set back to undefined, and error is no longer displayed
- submission.pending is true, spinner is rendered
